### PR TITLE
Sugestão de mudança na pagina de ciclo de vida.

### DIFF
--- a/basico/ciclo-de-vida.md
+++ b/basico/ciclo-de-vida.md
@@ -55,7 +55,7 @@ class _MeuWidgetImutavelState extends State<MeuWidgetImutavel> {
 }
 ```
 
-* O uso do "\_" torna o objeto imutável;
+* O uso do "\_" torna o widget privado para o escopo da biblioteca em que ele se encontra;
 * O uso de =&gt; indica que este método executa apenas 1 função.
 
 Mas não se engane, pois a diferença não é apenas no nome dos métodos. Lembra que ao criar um objeto do tipo [State](https://api.flutter.dev/flutter/widgets/State-class.html), um [Stateful](https://api.flutter.dev/flutter/widgets/StatefulWidget-class.html) widget ganha poderes mutáveis ?! Então, é dentro dele que a mágica acontece.


### PR DESCRIPTION
Corrigindo de acordo com a documentação oficial: https://dart.dev/guides/language/language-tour
```
Unlike Java, Dart doesn’t have the keywords public, protected, and private. If an identifier starts with an underscore (_), it’s private to its library. For details, see Libraries and visibility.
```