### PR TITLE
fix: change model to modelo

### DIFF
--- a/gerenciamento-de-estado/scoped_model.md
+++ b/gerenciamento-de-estado/scoped_model.md
@@ -17,7 +17,7 @@ Nossa classe com o\(s\) dado\(s\) que queremos compartilhar deve estender a clas
 ```dart
 void main() {
   runApp(MyApp(
-    model: ContadorModel(),
+    modelo: ContadorModel(),
   ));
 }
 
@@ -32,7 +32,7 @@ class MyApp extends StatelessWidget {
     // Ele irá prover ContadorModel para todos os widgetS filhos quando quando 
     // utilizarem o widget ScopedModelDescendant.
     return ScopedModel<ContadorModel>(
-      model: model,
+      model: modelo,
       child: MaterialApp(
         title: 'Scoped Model Demo',
         home: ContadorHome('Scoped Model Demo'),


### PR DESCRIPTION
The class `MyApp()` receives a parameter named `modelo`, not `model`:

<br>

❌
```dart
runApp(MyApp(
  model: ContadorModel(),
));
```
✔️
```dart
runApp(MyApp(
  modelo: ContadorModel(),
));
```